### PR TITLE
Add monitoring scripts for API health and TLS expiry

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,56 @@
+# Monitoring scripts
+
+This directory contains helper scripts to monitor the application.
+
+## `uptime.sh`
+Polls `/api/health` and `/api/status` periodically. The base URL and the polling interval can be set via the `BASE_URL` and `INTERVAL` environment variables. The script exits with a non‑zero status code when any request fails.
+
+Example:
+```bash
+BASE_URL=https://example.com INTERVAL=60 ./uptime.sh
+```
+
+## `tls_expiry.sh`
+Checks TLS certificate expiration for a host. The script exits with status 1 when the certificate is about to expire within the provided threshold.
+
+Usage:
+```bash
+./tls_expiry.sh example.com 443 30
+```
+The third argument is the number of days to warn before expiration.
+
+## Scheduling and alerts
+
+Run the scripts via `cron` or `systemd` timers and send alerts to Slack or email when they exit with a non‑zero status:
+
+### Cron
+```
+* * * * * /opt/monitoring/uptime.sh || curl -X POST -H 'Content-type: application/json' --data '{"text":"API is down"}' "$SLACK_WEBHOOK_URL"
+0 0 * * * /opt/monitoring/tls_expiry.sh example.com 443 30 || mail -s "TLS cert expiring" admin@example.com
+```
+
+### systemd timer
+Create `/etc/systemd/system/api-uptime.service`:
+```
+[Unit]
+Description=Check API health
+
+[Service]
+Type=oneshot
+ExecStart=/opt/monitoring/uptime.sh
+```
+Create `/etc/systemd/system/api-uptime.timer`:
+```
+[Unit]
+Description=Run API health check every minute
+
+[Timer]
+OnUnitActiveSec=1min
+Unit=api-uptime.service
+
+[Install]
+WantedBy=timers.target
+```
+Enable with `systemctl enable --now api-uptime.timer`.
+
+External services like Prometheus or UptimeRobot can also monitor these endpoints and forward alerts to Slack or email.

--- a/monitoring/tls_expiry.sh
+++ b/monitoring/tls_expiry.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HOST="${1:-localhost}"
+PORT="${2:-443}"
+WARN_DAYS="${3:-30}"
+
+expiry_date=$(echo | openssl s_client -servername "$HOST" -connect "$HOST:$PORT" 2>/dev/null | openssl x509 -noout -enddate | cut -d= -f2)
+
+if [[ -z "$expiry_date" ]]; then
+  echo "Failed to fetch certificate for $HOST:$PORT" >&2
+  exit 1
+fi
+
+expiry_epoch=$(date -d "$expiry_date" +%s)
+now_epoch=$(date +%s)
+
+days_left=$(( (expiry_epoch - now_epoch) / 86400 ))
+
+if (( days_left <= WARN_DAYS )); then
+  echo "Certificate for $HOST expires in $days_left days" >&2
+  exit 1
+else
+  echo "Certificate for $HOST valid for $days_left days"
+fi

--- a/monitoring/uptime.sh
+++ b/monitoring/uptime.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost}"
+INTERVAL="${INTERVAL:-60}"
+
+check() {
+  for path in /api/health /api/status; do
+    if ! curl -fsS "${BASE_URL}${path}" >/dev/null; then
+      echo "\"${BASE_URL}${path}\" is unreachable" >&2
+      return 1
+    fi
+  done
+}
+
+while true; do
+  if ! check; then
+    exit 1
+  fi
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary
- add `uptime.sh` to poll /api/health and /api/status
- add `tls_expiry.sh` to warn before certificate expiration
- document scheduling via cron or systemd with Slack/email notifications

## Testing
- `shellcheck monitoring/uptime.sh monitoring/tls_expiry.sh` *(fails: command not found)*
- `bash -n monitoring/uptime.sh monitoring/tls_expiry.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c1aed68f10832a917366d7cd4d94a6