### PR TITLE
feat: enhance landing page and login script

### DIFF
--- a/frontend/assets/app.js
+++ b/frontend/assets/app.js
@@ -39,7 +39,13 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log('Server response:', { status: res.status, headers: Object.fromEntries(res.headers.entries()), data });
   
         if (res.status === 200) {
-          setError('✅ Проверка учетных данных завершена', true);
+          if (data && data.token) {
+            localStorage.setItem('authToken', data.token);
+          }
+          setError('✅ Вход успешен. Перенаправляем...', true);
+          setTimeout(() => {
+            window.location.href = (data && data.redirect) ? data.redirect : '/dashboard';
+          }, 1000);
         } else if (res.status === 401) {
           setError((data && data.message) ? `${data.message} (код: ${data.error_code})` : 'Неавторизован');
         } else if (res.status === 423) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -83,12 +83,23 @@
             font-size: 0.8em;
             opacity: 0.7;
         }
+        .info {
+            margin: 15px 0;
+            font-size: 0.9em;
+            line-height: 1.4;
+        }
+        .registration-alert {
+            margin-top: 20px;
+            font-size: 0.9em;
+            opacity: 0.9;
+        }
     </style>
 </head>
 <body>
     <div class="container">
         <h1>🔐 Вход в систему</h1>
         <p>Digital Streamers Platform</p>
+        <p class="info">Платформа для организации и аналитики профессиональных стримов. Мы помогаем запускать трансляции и управлять аудиторией.</p>
 
         <form id="loginForm" action="/api/login" method="POST">
             <div class="form-group">
@@ -103,6 +114,8 @@
 
             <button type="submit" id="submitBtn">Войти</button>
         </form>
+
+        <p class="registration-alert">Регистрация новых пользователей временно недоступна.</p>
 
         <div id="errorMessage" class="error-message" style="display: none;">
             ⚠️ <strong>Ошибка авторизации</strong><br>


### PR DESCRIPTION
## Summary
- add platform info and registration unavailable notice to landing page
- handle successful login by storing token and redirecting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1bcb66984832aa7cc633562409c99